### PR TITLE
Document how to resize a filesystem manually

### DIFF
--- a/service-catalog/dev-desktops/how-to-increase-disk-size.md
+++ b/service-catalog/dev-desktops/how-to-increase-disk-size.md
@@ -90,6 +90,19 @@ nvme0n1      259:0    0    2T  0 disk
 └─nvme0n1p15 259:2    0   99M  0 part /boot/efi
 ```
 
+Also check with `df` if the filesystem has been resized:
+
+```shell
+df -h
+```
+
+If the filesystem has not been resized, you can use the `resize2fs` command to
+resize it manually:
+
+```shell
+resize2fs /dev/root
+```
+
 ## Azure
 
 On Azure, only one step is necessary since the filesystem is automatically


### PR DESCRIPTION
On one of the AWS dev-desktops, the filesystem was not resized automatically. It is very likely that it is always necessary to either resize the filesystem manually or restart the machine. Instructions have been added that show the command to resize manually.