### PR TITLE
Document permissions on Datadog

### DIFF
--- a/service-catalog/README.md
+++ b/service-catalog/README.md
@@ -14,6 +14,7 @@ how-to guides, explanations, and reference documentation.
 
 ## External Services
 
+- [Datadog](./datadog/README.md)
 - [Fastly](./fastly/README.md)
 
 [diataxis]: https://diataxis.fr/

--- a/service-catalog/datadog/README.md
+++ b/service-catalog/datadog/README.md
@@ -1,0 +1,17 @@
+# Datadog
+
+[Datadog] is a platform for monitoring and observability. It has integrations to
+gather metrics from most cloud providers, and offers additional features like
+application performance monitoring or a logging backend.
+
+We use the following features:
+
+- Host-level metrics using the [Datadog Agent](https://docs.datadoghq.com/agent/)
+- Platform-level metrics from AWS and Fastly
+- Log pipelines for logs from our CDNs, applications, and servers
+
+## Explanations
+
+- [About Permissions](./about-permissions.md)
+
+[datadog]: https://www.datadoghq.com/

--- a/service-catalog/datadog/about-permissions.md
+++ b/service-catalog/datadog/about-permissions.md
@@ -1,0 +1,58 @@
+# About Permissions
+
+> Permissions define the type of access a user has to a given resource.
+> Typically, permissions give a user the right to read, edit, or delete an
+> object.
+> (_[Source](https://docs.datadoghq.com/account_management/rbac/permissions/)_)
+
+We use [Datadog] to monitor our infrastructure and collect logs in a central
+location. This document outlines how permissions work and how we are granting
+them to users and teams.
+
+## Roles and Teams
+
+Permissions on [Datadog] are always assigned to a _role_. What a user can do on
+Datadog is thus determined by the roles they have.
+
+_Teams_, on the other hand, are mostly used to either filter data or to make it
+easier to find certain resources. The list of dashboards, for example, can be
+filtered to only show dashboards that are tagged with the user's teams.
+
+## Permissions for Metrics
+
+Metrics on [Datadog] can be seen and explored by every user. It is not possible
+to limit access to particular metrics, e.g. to grant a team access to only the
+metrics from their app.
+
+### Custom Metrics
+
+The creation of custom metrics is limited to a few roles, because they are not a
+free resource on Datadog. To ensure that we manage our costs responsibly,
+creating new custom metrics must be done in collaboration with an administrator
+who can monitor the impact that the new metrics have an our monthly billing.
+
+## Permissions for Dashboards
+
+Dashboards can be restricted in a few different ways:
+
+- Access to specific dashboards can be restricted to teams.
+- The creation of new dashboards can be limited to certain roles.
+- Making dashboards public can be limited to certain roles.
+
+Dashboards are generally available to all users on [Datadog], only the creation
+of new dashboards is disabled for some roles. Sharing a dashboard publicly is
+disabled for almost all users, except for administrators and staff of the Rust
+Foundation.
+
+## Permissions for Logs
+
+We use [Datadog] as a centralized logging platform. Access to logs is restricted
+to the teams that need to work with the specific logs. For example, only the
+`crates.io` team can see the logs from the Heroku app and the CDNs for
+`static.crates.io`.
+
+## Resources
+
+- [Datadog's documentation on RBAC](https://docs.datadoghq.com/account_management/rbac/permissions/)
+
+[datadog]: ./README.md


### PR DESCRIPTION
We use Datadog to manage our infrastructure and collect logs in a centralized platform. A short overview has been created that documents what permissions there are and how we use them.