### PR TITLE
docs: remove instruction on dev-desktops update guide

### DIFF
--- a/service-catalog/dev-desktops/how-to-update-system.md
+++ b/service-catalog/dev-desktops/how-to-update-system.md
@@ -37,6 +37,5 @@ To update the Ubuntu version:
 1. Update the packages as described above.
 2. Run `sudo do-release-upgrade` to upgrade to the next LTS version.
 3. The system should reboot automatically after the upgrade.
-4. Run `sudo apt --fix-broken install` to fix any broken packages.
-5. Apply the Ansible playbook again to ensure it still works
-6. Reboot the machine to ensure all services are running with the latest versions: `sudo reboot now`
+4. Apply the Ansible playbook again to ensure it still works
+5. Reboot the machine to ensure all services are running with the latest versions: `sudo reboot now`


### PR DESCRIPTION
this is not always required, so I'm deleting it