### PR TITLE
Run checks on the correct branch

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -4,7 +4,7 @@ name: JSON
 "on":
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -4,7 +4,7 @@ name: Markdown
 "on":
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run markdownlint
         uses: nosborn/github-action-markdown-cli@v3.3.0
         with:
-          files: "**.md"
+          files: "**/*.md"
 
   style:
     name: Check style

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -4,7 +4,7 @@ name: YAML
 "on":
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/service-catalog/bors/README.md
+++ b/service-catalog/bors/README.md
@@ -5,14 +5,14 @@
 
 - The bors infrastructure is managed in the
   [bors](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/bors)
-  terragrunt module and it's deployed in the
-  `bors-staging` and `bors-prod` account, depending on the environment.
-- The `homu` infrastructure is managed in the
-  [terraform/bors](https://github.com/rust-lang/simpleinfra/tree/master/terraform/bors) module and it is deployed in the legacy account.
+  terragrunt module and is deployed in the `bors-staging` and `bors-prod`
+  account, depending on the environment.
+- The `homu` infrastructure is managed in the [terraform/bors](https://github.com/rust-lang/simpleinfra/tree/master/terraform/bors)
+  module and is deployed in the legacy account.
 
 Bors is deployed as a [Fargate](https://aws.amazon.com/fargate/) service
-([ECS](https://aws.amazon.com/ecs/)) in the `us-east-2` region.
-Bors uses an RDS PostgreSQL database.
+([ECS](https://aws.amazon.com/ecs/)) in the `us-east-2` region. Bors uses an RDS
+PostgreSQL database.
 
 To deploy a new version, the
 [deployment](https://github.com/rust-lang/bors/blob/main/.github/workflows/deploy.yml)

--- a/service-catalog/crater/README.md
+++ b/service-catalog/crater/README.md
@@ -2,12 +2,14 @@
 
 `Crater` is a tool to run experiments across parts of the Rust ecosystem.
 
-The `crater` service is managed in the [terraform/crater] module, while the app is in the [rust-lang/crater] repository.
+The `crater` service is managed in the [terraform/crater] module, while the app
+is in the [rust-lang/crater] repository.
 
 You can find the detailed `crater` docs
 [here](https://github.com/rust-lang/crater/tree/master/docs).
 
-[crater.rust-lang.org] shows the status of the running experiments and the agents.
+[crater.rust-lang.org] shows the status of the running experiments and the
+agents.
 
 ## Architecture
 
@@ -28,9 +30,9 @@ graph LR
 
 The agents and crater communicate over HTTP.
 
-The agents communicate to crater their capabilities
-(e.g. "windows" or "hard-drive-bigger-than-1TB") and crater assigns experiments
-based on these capabilities.
+The agents communicate to crater their capabilities (e.g. "windows" or
+"hard-drive-bigger-than-1TB") and crater assigns experiments based on these
+capabilities.
 
 ## Bot
 
@@ -41,7 +43,7 @@ is prefixed with the bot's username.
 
 For example, to check if the bot is alive you can write this comment:
 
-```
+```shell
 @craterbot ping
 ```
 

--- a/service-catalog/crater/how-to-test-crater.md
+++ b/service-catalog/crater/how-to-test-crater.md
@@ -3,17 +3,20 @@
 After you do infra changes to crater, you might want to run a quick e2e test, to
 make sure everything continues working as expected.
 
-For an in-depth guide on how to use the crater bot from the `rust-lang/rust` repository,
-check the [bot-usage](https://github.com/rust-lang/crater/blob/master/docs/bot-usage.md)
-document.
-However, if you want to run a quick test, here's how to do it:
+For an in-depth guide on how to use the crater bot from the `rust-lang/rust`
+repository, check the [bot-usage](https://github.com/rust-lang/crater/blob/master/docs/bot-usage.md)
+document. However, if you want to run a quick test, here's how to do it:
 
 1. Identify a PR where the bors testing succeeded, like
-   [this](https://github.com/rust-lang/rust/pull/131362#issuecomment-2421811741) one.
+   [this](https://github.com/rust-lang/rust/pull/131362#issuecomment-2421811741)
+   one.
 2. Comment on the PR with the following command:
-   ```
+
+   ```shell
    @craterbot run mode=check-only crates=https://gist.githubusercontent.com/MarcoIeni/3800cdca02ddb30ac98404cafa849c1b/raw/crates start=master#<start_commit> end=try#<end_commit>
    ```
+
    Example [here](https://github.com/rust-lang/rust/pull/131362#issuecomment-2435412130).
+
 3. You should see the bot reply with a link to the crater [queue](https://crater.rust-lang.org/).
    Example [here](https://github.com/rust-lang/rust/pull/131362#issuecomment-2435412322).

--- a/service-catalog/crater/how-to-update-crater.md
+++ b/service-catalog/crater/how-to-update-crater.md
@@ -4,19 +4,20 @@ Crater is made of various components, here's how to update them.
 
 > [!NOTE]
 > Before updating crater check on [crater.rust-lang.org] if there are any running
+> experiments. It's preferable to update crater when there are no running
 > experiments.
-> It's preferable to update crater when there are no running experiments.
 
 ## Agents
 
-To update the ubuntu version of the agents, you need to update the [agent template].
+To update the ubuntu version of the agents, you need to update the
+[agent template].
 
-After you update ubuntu, verify that the agent are still reachable by the crater server at in
-the [crater](https://crater.rust-lang.org/agents) website.
+After you update ubuntu, verify that the agent are still reachable by the crater
+server at in the [crater](https://crater.rust-lang.org/agents) website.
 
 If the agents are not reachable, ssh into the agents VMs and run the command
-`journalctl` to see what's wrong.
-You can find the VMs in the [GCP console](https://console.cloud.google.com/compute/instances).
+`journalctl` to see what's wrong. You can find the VMs in the
+[GCP console](https://console.cloud.google.com/compute/instances).
 
 ## Crater server
 
@@ -26,9 +27,9 @@ These are the versions we need to keep up-to-date:
 - Cargo dependencies: specified in the [Cargo.lock]
 - GitHub Actions: specified in the [workflows] directory
 
-Plus, update the Ubuntu version of the VM by ssh-ing into it (similarly to how you would
-[update a dev-desktop](../dev-desktops/how-to-update-system.md)).
-The reason for updating the same VM instead of replacing it, is that crater has a
+Plus, update the Ubuntu version of the VM by ssh-ing into it (similarly to how
+you would [update a dev-desktop](../dev-desktops/how-to-update-system.md)). The
+reason for updating the same VM instead of replacing it, is that crater has a
 SQLite database that would be lost if the VM was replaced.
 
 [agent template]: https://github.com/rust-lang/simpleinfra/blob/74bbf479de315fb5c5d6e97832fc3dc9b12e4cab/terraform/crater/agent.tf#L139

--- a/service-catalog/crates-io/README.md
+++ b/service-catalog/crates-io/README.md
@@ -1,10 +1,9 @@
 # Crates.io
 
-Crates.io is the Rust community's package registry.
-The crates.io
+Crates.io is the Rust community's package registry. The crates.io
 [team](https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io)
-develops [crates-io](https://github.com/rust-lang/crates.io)
-and the Infra team helps with the infrastructure.
+develops [crates-io](https://github.com/rust-lang/crates.io) and the Infra team
+helps with the infrastructure.
 
 The crates.io app is deployed in Heroku, you can learn more about it in the
 crates-io [docs](https://github.com/rust-lang/crates.io/blob/main/docs/ARCHITECTURE.md).
@@ -14,9 +13,11 @@ Here are the details of the crates.io infrastructure managed by the infra team:
 - [crates-io-logs](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/crates-io-logs):
   the infrastructure that counts crates downloads.
   It is deployed in the AWS accounts `crates-io-prod` and `crates-io-staging`.
-- [crates-io](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/crates-io): Terraform module for the crates.io infrastructure.
+- [crates-io](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/crates-io):
+  Terraform module for the crates.io infrastructure.
 - [crates-io-heroku-metrics](https://github.com/rust-lang/simpleinfra/tree/master/terraform/crates-io-heroku-metrics):
-  Terraform module that deploys the Heroku metrics [collector](https://github.com/rust-lang/crates-io-heroku-metrics) used to gather crates.io's metrics.
+  Terraform module that deploys the Heroku metrics [collector](https://github.com/rust-lang/crates-io-heroku-metrics)
+  used to gather crates.io's metrics.
 
 ## Versions
 

--- a/service-catalog/dev-desktops/how-to-update-system.md
+++ b/service-catalog/dev-desktops/how-to-update-system.md
@@ -38,4 +38,5 @@ To update the Ubuntu version:
 2. Run `sudo do-release-upgrade` to upgrade to the next LTS version.
 3. The system should reboot automatically after the upgrade.
 4. Apply the Ansible playbook again to ensure it still works
-5. Reboot the machine to ensure all services are running with the latest versions: `sudo reboot now`
+5. Reboot the machine to ensure all services are running with the latest
+   versions: `sudo reboot now`

--- a/service-catalog/dns/README.md
+++ b/service-catalog/dns/README.md
@@ -1,8 +1,10 @@
 # DNS
 
-- The [terraform/dns] module configures DNS records of resources **not** managed by Terraform.
+- The [terraform/dns] module configures DNS records of resources **not** managed
+  by Terraform.
 - The [terraform/dns-delegation] module configures the `rust-lang.net` domain.
-- The [terraform/domain-redirects] module configures domain redirects (e.g. `cratesio.com` to `crates.io`).
+- The [terraform/domain-redirects] module configures domain redirects (e.g.
+  `cratesio.com` to `crates.io`).
 
 [terraform/dns]: https://github.com/rust-lang/simpleinfra/tree/master/terraform/dns
 [terraform/dns-delegation]: https://github.com/rust-lang/simpleinfra/tree/master/terraform/dns-delegation

--- a/service-catalog/docs-rs/README.md
+++ b/service-catalog/docs-rs/README.md
@@ -2,16 +2,16 @@
 
 Docs.rs is a service that hosts documentation of crates.
 
-The docs.rs codebase is available at [rust-lang/docs.rs] and
-it's maintained by the [docs.rs team](https://www.rust-lang.org/governance/teams/dev-tools#team-docs-rs).
+The docs.rs codebase is available at [rust-lang/docs.rs] and is maintained by
+the [docs.rs team](https://www.rust-lang.org/governance/teams/dev-tools#team-docs-rs).
 
 The infrastructure is managed via the [terraform/docs-rs] module.
 
 The EC2 `docsrs.infra.rust-lang.org` is served by Cloudfront CDN at `docs.rs`.
 
-Docs.rs also uses the `rust-docs-rs` S3 bucket which is served
-through the docs.rs webserver itself, and additionally through the Cloudfront CDN `static.docs.rs`.
-Docs.rs rewrites the doc pages before serving them.
+Docs.rs also uses the `rust-docs-rs` S3 bucket which is served through the
+docs.rs webserver itself, and additionally through the Cloudfront CDN
+`static.docs.rs`. Docs.rs rewrites the doc pages before serving them.
 
 [rust-lang/docs.rs]: https://github.com/rust-lang/docs.rs
 [terraform/docs-rs]: https://github.com/rust-lang/simpleinfra/tree/master/terraform/docs-rs

--- a/service-catalog/fastly/README.md
+++ b/service-catalog/fastly/README.md
@@ -5,7 +5,9 @@ available closer to the user.
 
 ## Fastly Exporter
 
-[terraform/fastly-exporter] deploys the fastly-exporter, which makes the [Fastly Real-time analytics](https://www.fastly.com/documentation/reference/api/metrics-stats/realtime/) data available to Prometheus.
+[terraform/fastly-exporter] deploys the fastly-exporter, which makes the
+[Fastly Real-time analytics](https://www.fastly.com/documentation/reference/api/metrics-stats/realtime/)
+data available to Prometheus.
 
 ## Team members
 

--- a/service-catalog/monitorbot/README.md
+++ b/service-catalog/monitorbot/README.md
@@ -1,7 +1,8 @@
 # Monitorbot
 
 Bot that monitors various APIs and services that the infrastructure team uses.
-For example, it's used to check if GitHub tokens are getting close to their rate limits.
+For example, it's used to check if GitHub tokens are getting close to their rate
+limits.
 
 [terraform/monitorbot] deploys the monitorbot as an ECS app.
 

--- a/service-catalog/releases/README.md
+++ b/service-catalog/releases/README.md
@@ -3,9 +3,11 @@
 Here's the infrastructure we use to distribute the Rust releases:
 
 - [release-distribution](https://github.com/rust-lang/simpleinfra/blob/master/terragrunt/modules/release-distribution/):
-  Terraform module that uses Cloudfront and Fastly to manage the distribution of releases via `static-rust-lang-org`.
+  Terraform module that uses Cloudfront and Fastly to manage the distribution of
+  releases via `static-rust-lang-org`.
 - [releases](https://github.com/rust-lang/simpleinfra/blob/docs-document-release-distribution/terraform/releases/):
-  Terraform module managing the infrastructure that publishes Rust releases, including [promote-release](https://github.com/rust-lang/promote-release),
+  Terraform module managing the infrastructure that publishes Rust releases,
+  including [promote-release](https://github.com/rust-lang/promote-release),
   the tool used to publish new releases of the Rust toolchain.
 
 ## Versions
@@ -16,7 +18,8 @@ Here's the infrastructure we use to distribute the Rust releases:
 
 `promote-releases` repo:
 
-- [Cargo.toml](https://github.com/rust-lang/promote-release/blob/master/Cargo.toml) dependencies
+- [Cargo.toml](https://github.com/rust-lang/promote-release/blob/master/Cargo.toml)
+  dependencies
 - GitHub Actions: specified in the
   [workflows](https://github.com/rust-lang/promote-release/tree/master/.github/workflows)
   directory

--- a/service-catalog/rust-ci/README.md
+++ b/service-catalog/rust-ci/README.md
@@ -1,11 +1,15 @@
 # Rust CI
 
-The Infrastructure team maintains the [rust-lang/rust] Continuous Integration, which lives in the [workflows] directory.
+The Infrastructure team maintains the [rust-lang/rust] Continuous Integration,
+which lives in the [workflows] directory.
 
 The [terraform/rust-ci] module provisions some resources used by the CI:
 
-- the `rust-lang-ci-sccache2` S3 bucket, used to store [sscache] compilation artifacts to speed up the rustc compile time. Served by Cloudfront CDN at `ci-caches.rust-lang.org`.
-- the `rust-lang-ci2` S3 bucket, used to store compilation artifacts. Served by Cloudfront CDN at `ci-artifacts.rust-lang.org`.
+- The `rust-lang-ci-sccache2` S3 bucket, used to store [sscache] compilation
+  artifacts to speed up the rustc compile time and served by Cloudfront CDN at
+  `ci-caches.rust-lang.org`.
+- The `rust-lang-ci2` S3 bucket, used to store compilation artifacts and served
+  by Cloudfront CDN at `ci-artifacts.rust-lang.org`.
 
 [sscache]: https://github.com/mozilla/sccache
 [terraform/rust-ci]: https://github.com/rust-lang/simpleinfra/tree/master/terraform/rustc-ci

--- a/service-catalog/rust-log-analyzer/README.md
+++ b/service-catalog/rust-log-analyzer/README.md
@@ -1,8 +1,10 @@
 # Rust Log Analyzer
 
-[rust-log-analyzer] is a tool that analyzes the CI build logs of the [rust] repository to automatically extract error messages from failed builds.
+[rust-log-analyzer] is a tool that analyzes the CI build logs of the [rust]
+repository to automatically extract error messages from failed builds.
 
-This tool is deployed via the [terraform/rust-log-analyzer] module as an ECS service and uses S3 to store the GitHub actions index.
+This tool is deployed via the [terraform/rust-log-analyzer] module as an ECS
+service and uses S3 to store the GitHub actions index.
 
 ## Versions
 

--- a/service-catalog/rustc-perf/README.md
+++ b/service-catalog/rustc-perf/README.md
@@ -1,19 +1,19 @@
 # Rustc perf
 
-[Rustc perf] is a website that tracks the performance of
-`rustc` over time.
+[Rustc perf] is a website that tracks the performance of `rustc` over time.
 
-It is deployed using [terraform/rustc-perf].
-The app is in the [rustc-perf]
-repository and it's maintained by the [wg-compiler-performance] team.
+It is deployed using [terraform/rustc-perf]. The app is in the [rustc-perf]
+repository and is maintained by the [wg-compiler-performance] team.
 
-It uses an ECR repository to store the Docker image and an ECS service to run it.
+It uses an ECR repository to store the Docker image and an ECS service to run
+it.
 
 It also uses the `shared` db of [rds-databases] and the `rustc-perf` S3 bucket.
 
-The collector (the machine that runs the benchmarks) is a dedicated physical server running at [Hetzner].
-Rustc-perf runs on a bare-metal server because we need predictable performance.
-Otherwise, test results might be spoiled by noisy neighbors in the cloud.
+The collector (the machine that runs the benchmarks) is a dedicated physical
+server running at [Hetzner]. Rustc-perf runs on a bare-metal server because we
+need predictable performance. Otherwise, test results might be spoiled by noisy
+neighbors in the cloud.
 
 ## Versions
 

--- a/service-catalog/rustup/README.md
+++ b/service-catalog/rustup/README.md
@@ -14,5 +14,6 @@ The Infra team maintains the infrastructure for Rustup:
   to this S3 bucket.
 - [win-rustup-rs](https://github.com/rust-lang/simpleinfra/tree/master/terragrunt/modules/win-rustup-rs)
   terragrunt module.
-  A Cloudfront distribution of the `/rustup/dist` path of the `static-rust-lang-org` bucket providing convenient short for downloading
+  A Cloudfront distribution of the `/rustup/dist` path of the
+  `static-rust-lang-org` bucket providing convenient short for downloading
   rustup on Windows.


### PR DESCRIPTION
When pushing code to the default branch, we want to run the GitHub Actions workflows to ensure that the branch builds cleanly. This was configured with the wrong branch name and has been fixed.