### PR TITLE
link zulip channels in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ You can see what we are working on and our backlog in our
 Interested in contributing? Check out our
 [good first issues](https://github.com/orgs/rust-lang/projects/24/views/3)
 
+## Zulip
+
+We have two Zulip channels:
+
+- [t-infra](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra) for general discussions
+- [t-infra/announcements](https://forge.rust-lang.org/infra/docs/internal-announcements.html) for important announcements
+
 ## Repositories
 
 Some of the repositories we work on:

--- a/service-catalog/README.md
+++ b/service-catalog/README.md
@@ -32,7 +32,6 @@ how-to guides, explanations, and reference documentation.
 - [rustup](./rustup/README.md)
 - [sync-team](./sync-team/README.md)
 - [team-member-access](./team-member-access/README.md)
-- [Internal-facing infrastructure announcements](./internal-facing-infra-announcements/README.md)
 
 ## External Services
 

--- a/service-catalog/internal-facing-infra-announcements/README.md
+++ b/service-catalog/internal-facing-infra-announcements/README.md
@@ -1,3 +1,0 @@
-# Internal-facing infrastructure announcements
-
-See <https://forge.rust-lang.org/infra/docs/internal-announcements.html>.


### PR DESCRIPTION
This reverts https://github.com/rust-lang/infra-team/pull/224 because imo a zulip stream is not really a "service" so it doesn't belong to the service-catalog.

Instead, I listed our two zulip channels in the readme.