### PR TITLE
document public dashboard (again)

### DIFF
--- a/service-catalog/rust-ci/public-dashboard.md
+++ b/service-catalog/rust-ci/public-dashboard.md
@@ -1,0 +1,12 @@
+# Public dashboard
+
+Datadog can only be accessed by certain Rust teams.
+However certain data are useful to everyone, so the infra team created a
+[public dashboard](https://p.datadoghq.com/sb/3a172e20-e9e1-11ed-80e3-da7ad0900002-b5f7bb7e08b664a06b08527da85f7e30)
+to monitor the Rust CI.
+
+This dashboard is just a clone of the Datadog CI
+[dashboard](https://docs.datadoghq.com/continuous_integration/?site=us).
+
+This dashboard is also documented in the
+[rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/tests/ci.html#public-ci-dashboard).


### PR DESCRIPTION
See https://github.com/rust-lang/rustc-dev-guide/pull/2843

The dashboard was deleted in https://github.com/rust-lang/infra-team/pull/242